### PR TITLE
Escaping n Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,3 @@ And many thanks to the following folks who helped with testing and QA:
 * [Rob Neue](https://twitter.com/rob_neu)
 * [Gary Jones](https://twitter.com/GaryJ)
 * [Jan Hoek](https://twitter.com/JanHoekdotCom)
-
-## TO DO ##
-* Update readme!
-* Check to make sure plugin isn't deactivating on update (seemed to happen once before).

--- a/better-font-awesome.php
+++ b/better-font-awesome.php
@@ -12,7 +12,7 @@
  * Plugin Name:       Better Font Awesome
  * Plugin URI:        http://wordpress.org/plugins/better-font-awesome
  * Description:       The ultimate Font Awesome icon plugin for WordPress.
- * Version:           1.0.0
+ * Version:           1.0.3
  * Author:            MIGHTYminnow & Mickey Kay
  * Author URI:        mickey@mickeykaycreative.com
  * License:           GPLv2+
@@ -176,7 +176,7 @@ class Better_Font_Awesome_Plugin {
     private function initialize() {
         
         // Set display name.
-        $this->plugin_display_name = __( 'Better Font Awesome', 'bfa' );
+        $this->plugin_display_name = __( 'Better Font Awesome', 'better-font-awesome' );
 
         // Set options name.
         $this->option_name = self::SLUG . '_options';
@@ -213,9 +213,9 @@ class Better_Font_Awesome_Plugin {
         
         deactivate_plugins( plugin_basename( __FILE__ ) );
 
-        $message = '<h2>' . __( 'Better Font Awesome', 'bfa' ) . '</h2>';
-            $message .= '<p>' . __( 'It appears that Better Font Awesome is missing it\'s <a href="https://github.com/MickeyKay/better-font-awesome-library" target="_blank">core library</a>, which typically occurs when cloning the Git repository and not updating all submodules. Please refer to the plugin\'s <a href="https://github.com/MickeyKay/better-font-awesome" target="_blank">installation instructions</a> for details on how to properly install Better Font Awesome via Git. If you installed from within WordPress, or via the wordpress.org repo, then chances are the install failed and you can try again. If the issue persists, please create a new topic on the plugin\'s <a href="http://wordpress.org/support/plugin/better-font-awesome" target="_blank">support forum</a> or file an issue on the <a href="https://github.com/MickeyKay/better-font-awesome/issues" target="_blank">Github repo</a>.' , 'bfa' ) . '</p>';
-            $message .= '<p><a href="' . get_admin_url( null, 'plugins.php' ) . '">' . __( 'Back to the plugins page &rarr;', 'bfa' ) . '</a></p>';
+        $message = '<h2>' . __( 'Better Font Awesome', 'better-font-awesome' ) . '</h2>';
+            $message .= '<p>' . __( 'It appears that Better Font Awesome is missing it\'s <a href="https://github.com/MickeyKay/better-font-awesome-library" target="_blank">core library</a>, which typically occurs when cloning the Git repository and not updating all submodules. Please refer to the plugin\'s <a href="https://github.com/MickeyKay/better-font-awesome" target="_blank">installation instructions</a> for details on how to properly install Better Font Awesome via Git. If you installed from within WordPress, or via the wordpress.org repo, then chances are the install failed and you can try again. If the issue persists, please create a new topic on the plugin\'s <a href="http://wordpress.org/support/plugin/better-font-awesome" target="_blank">support forum</a> or file an issue on the <a href="https://github.com/MickeyKay/better-font-awesome/issues" target="_blank">Github repo</a>.' , 'better-font-awesome' ) . '</p>';
+            $message .= '<p><a href="' . get_admin_url( null, 'plugins.php' ) . '">' . __( 'Back to the plugins page &rarr;', 'better-font-awesome' ) . '</a></p>';
 
             wp_die( $message );
             
@@ -349,7 +349,7 @@ class Better_Font_Awesome_Plugin {
 
         add_settings_field(
             'version', // ID
-            __( 'Version', 'bfa' ), // Title
+            __( 'Version', 'better-font-awesome' ), // Title
             array( $this, 'version_callback' ), // Callback
             self::SLUG, // Page
             'settings_section_primary', // Section
@@ -358,25 +358,25 @@ class Better_Font_Awesome_Plugin {
 
         add_settings_field(
             'minified',
-            __( 'Use minified CSS', 'bfa' ),
+            __( 'Use minified CSS', 'better-font-awesome' ),
             array( $this, 'checkbox_callback' ),
             self::SLUG,
             'settings_section_primary',
             array(
                 'id' => 'minified',
-                'description' => __( 'Whether to include the minified version of the CSS (checked), or the unminified version (unchecked).', 'bfa' ),
+                'description' => __( 'Whether to include the minified version of the CSS (checked), or the unminified version (unchecked).', 'better-font-awesome' ),
             )
         );
 
         add_settings_field(
             'remove_existing_fa',
-            __( 'Remove existing Font Awesome', 'bfa' ),
+            __( 'Remove existing Font Awesome', 'better-font-awesome' ),
             array( $this, 'checkbox_callback' ),
             self::SLUG,
             'settings_section_primary',
             array(
                 'id' => 'remove_existing_fa',
-                'description' => __( 'Attempt to remove Font Awesome CSS and shortcodes added by other plugins and themes.', 'bfa' ),
+                'description' => __( 'Attempt to remove Font Awesome CSS and shortcodes added by other plugins and themes.', 'better-font-awesome' ),
             )
         );
 
@@ -393,7 +393,7 @@ class Better_Font_Awesome_Plugin {
     function get_versions_list() {
 
         if ( $this->bfa_lib->get_api_value('versions') ) {
-            $versions['latest'] = __( 'Always Latest', 'bfa' );
+            $versions['latest'] = __( 'Always Latest', 'better-font-awesome' );
 
             foreach ( $this->bfa_lib->get_api_value('versions') as $version ) {
                 $versions[ $version ] = $version;
@@ -419,7 +419,7 @@ class Better_Font_Awesome_Plugin {
         if ( $versions ) {
 
             // Add 'Always Latest' option.
-            $versions['latest'] = __( 'Always Latest', 'bfa' );
+            $versions['latest'] = __( 'Always Latest', 'better-font-awesome' );
 
             /**
              * Remove version 2.0, since its CSS doesn't work with the regex
@@ -453,21 +453,21 @@ class Better_Font_Awesome_Plugin {
             ?>
             <p>
                 <?php 
-                printf( __( 'Version selection is currently unavailable. The attempt to reach the jsDelivr API server failed with the following error: %s', 'bfa' ), 
+                printf( __( 'Version selection is currently unavailable. The attempt to reach the jsDelivr API server failed with the following error: %s', 'better-font-awesome' ), 
                     '<code>' . $this->bfa_lib->get_error('api')->get_error_code() . ': ' . $this->bfa_lib->get_error('api')->get_error_message() . '</code>'
                 );
                 ?>
             </p>
             <p>
                 <?php 
-                printf( __( 'Font Awesome will still render using version: %s', 'bfa' ),
-                    '<code>' . $this->bfa_lib->get_version() . '</code>'
+                printf( __( 'Font Awesome will still render using version: %s', 'better-font-awesome' ),
+                    '<code>' . $this->bfa_lib->get_fallback_version() . '</code>'
                 );
                 ?>
             </p>
             <p>
                 <?php
-                printf( __( 'This may be the result of a temporary server or connectivity issue which will resolve shortly. However if the problem persists please file a support ticket on the %splugin forum%s, citing the errors listed above. ', 'bfa' ),
+                printf( __( 'This may be the result of a temporary server or connectivity issue which will resolve shortly. However if the problem persists please file a support ticket on the %splugin forum%s, citing the errors listed above. ', 'better-font-awesome' ),
                         '<a href="http://wordpress.org/support/plugin/better-font-awesome" target="_blank" title="Better Font Awesome support forum">',
                         '</a>'
                 );
@@ -523,7 +523,7 @@ class Better_Font_Awesome_Plugin {
                      <i class="icon-coffee fa fa-coffee"></i> <code>[icon name="coffee"]</code> or <code>&lt;i class="icon-coffee"&gt;&lt;/i&gt;</code><br /><br />
                      <i class="icon-coffee fa fa-coffee icon-2x fa-2x"></i> <code>[icon name="coffee" class="icon-2x"]</code> or <code>&lt;i class="icon-coffee icon-2x"&gt;&lt;/i&gt;</code><br /><br />
                      <i class="icon-coffee fa fa-coffee icon-2x fa-2x icon-rotate-90 fa-rotate-90"></i> <code>[icon name="coffee" class="icon-2x icon-rotate-90"]</code> or <code>&lt;i class="icon-coffee icon-2x icon-rotate-90"&gt;&lt;/i&gt;</code>',
-                'bfa' ) .
+                'better-font-awesome' ) .
                 '</div>';
     }
 

--- a/better-font-awesome.php
+++ b/better-font-awesome.php
@@ -12,7 +12,7 @@
  * Plugin Name:       Better Font Awesome
  * Plugin URI:        http://wordpress.org/plugins/better-font-awesome
  * Description:       The ultimate Font Awesome icon plugin for WordPress.
- * Version:           1.0.3
+ * Version:           1.0.5
  * Author:            MIGHTYminnow & Mickey Kay
  * Author URI:        mickey@mickeykaycreative.com
  * License:           GPLv2+
@@ -267,7 +267,7 @@ class Better_Font_Awesome_Plugin {
     private function initialize_better_font_awesome_library( $options ) {
         
         $args = array(
-            'version'             => $options['version'] ? $options['version'] : $this->option_defaults['version'],
+            'version'             => isset( $options['version'] ) ? $options['version'] : $this->option_defaults['version'],
             'minified'            => isset( $options['minified'] ) ? $options['minified'] : '',
             'remove_existing_fa'  => isset( $options['remove_existing_fa'] ) ? $options['remove_existing_fa'] :'',
             'load_styles'         => true,

--- a/better-font-awesome.php
+++ b/better-font-awesome.php
@@ -12,7 +12,7 @@
  * Plugin Name:       Better Font Awesome
  * Plugin URI:        http://wordpress.org/plugins/better-font-awesome
  * Description:       The ultimate Font Awesome icon plugin for WordPress.
- * Version:           0.0.1
+ * Version:           1.0.0
  * Author:            MIGHTYminnow & Mickey Kay
  * Author URI:        mickey@mickeykaycreative.com
  * License:           GPLv2+
@@ -20,8 +20,6 @@
  * Domain Path:       /languages
  * GitHub Plugin URI: https://github.com/MickeyKay/better-font-awesome
  */
-
-//register_activation_hook( __FILE__, array( 'Better_Font_Awesome_Plugin', 'activation_check' ) );
 
 add_action( 'plugins_loaded', 'bfa_start', 5 );
 /**
@@ -184,7 +182,7 @@ class Better_Font_Awesome_Plugin {
         $this->option_name = self::SLUG . '_options';
 
         // Set up main Better Font Awesome Library file path.
-        $this->bfa_lib_file_path = plugin_dir_path( __FILE__ ) . 'lsib/better-font-awesome-library/better-font-awesome-library.php';
+        $this->bfa_lib_file_path = plugin_dir_path( __FILE__ ) . 'lib/better-font-awesome-library/better-font-awesome-library.php';
 
         // Get plugin options, and populate defaults as needed.
         $this->initialize_options( $this->option_name );

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: McGuive7, MIGHTYminnow
 Tags: better, font, awesome, icon, icons, bootstrap, fontstrap, cdn, shortcode
 Donate link: http://mightyminnow.com
 Requires at least: 3.0
-Tested up to: 3.9
-Stable tag: 1.0.0
+Tested up to: 4.1
+Stable tag: 1.0.5
 License: GPLv2+
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -54,6 +54,9 @@ Note that prefixes are required for HTML usage, and are version-specific. For th
 = Advanced / Integration =
 Better Font Awesome is built around the [Better Font Awesome Library](https://github.com/MickeyKay/better-font-awesome-library). This library allows you to integrate Better Font Awesome into any custom project you want to create (perhaps a theme or plugin with a constantly up-to-date icon list), and includes all the [filters](https://github.com/MickeyKay/better-font-awesome-library#filters) you might need.
 
+= Languages / Translations =
+* English
+* French (thanks to [David Tisserand](http://www.pixemotion.fr))
 
 = Credits =
 Many thanks to the following plugins and their authors:
@@ -64,6 +67,7 @@ Many thanks to the following plugins and their authors:
 * Dmitriy Akulov and the awesome folks at [jsDelivr](http://www.jsdelivr.com/)
 
 And many thanks to the following folks who helped with testing and QA:
+
 * [Jeffrey Dubinksy](http://vanishingforests.org/)
 * [Neil Gee](https://twitter.com/_neilgee)
 * [Michael Beil](https://twitter.com/MichaelBeil)
@@ -104,6 +108,24 @@ Better Font Awesome does it's best to load after any existing Font Awesome CSS, 
 
 == Changelog ==
 
+= 1.0.5 =
+* Add fa_force_fallback and bfa_show_errors filters.
+* Add hex icon values as $icon array indexes.
+
+= 1.0.4 =
+* Add missing isset() check that was causing intermittent warning.
+
+= 1.0.3 =
+* Add French translation.
+* Correct text domain slug.
+
+= 1.0.2 =
+* Add updated .pot file.
+* Further improve error handling and fallback.
+
+= 1.0.1 =
+* Fix error handling for 404 API requests.
+
 = 1.0.0 =
 * Fully refactor the back-end.
 * Switch to just using the jsDelivr CDN.
@@ -139,6 +161,24 @@ Better Font Awesome does it's best to load after any existing Font Awesome CSS, 
 
 
 == Upgrade Notice ==
+
+= 1.0.5 =
+* Add fa_force_fallback and bfa_show_errors filters.
+* Add hex icon values as $icon array indexes.
+
+= 1.0.4 =
+* Add missing isset() check that was causing intermittent warning.
+
+= 1.0.3 =
+* Add French translation.
+* Correct text domain slug.
+
+= 1.0.2 =
+* Add updated .pot file.
+* Further improve error handling and fallback.
+
+= 1.0.1 =
+* Fix error handling for 404 API requests.
 
 = 1.0.0 =
 * Fully refactor the back-end.

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Better Font Awesome ===
 Contributors: McGuive7, MIGHTYminnow
-Tags: better, font, awesome, icon, bootstrap, fontstrap, cdn, shortcode
+Tags: better, font, awesome, icon, icons, bootstrap, fontstrap, cdn, shortcode
 Donate link: http://mightyminnow.com
 Requires at least: 3.0
 Tested up to: 3.9
-Stable tag: 0.0.1
+Stable tag: 1.0.0
 License: GPLv2+
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,18 +12,20 @@ The Better Font Awesome plugin for WordPress. Shortcodes, HTML, TinyMCE, various
 
 == Description ==
 
-Better Font Awesome gives you easy access to the full [Font Awesome](http://fortawesome.github.io/Font-Awesome/ "Font Awesome icon website") icon library using shortcodes, HTML, and TinyMCE, and allows you to update your version of Font Awesome without having to change your existing shortcodes.
+Better Font Awesome allows you to automatically integrate the latest available version of [Font Awesome](http://fontawesome.io/) into your WordPress project, along with accompanying CSS, shortcodes, and TinyMCE icon shortcode generator.
 
 
 = Features =
 
-* **Choose your version** - automatically checks for all available versions of Font Awesome, and lets you choose which one you want to use from a simple drop down menu. You also have the option to choose "Latest," which means the plugin will automatically switch to the latest version of Font Awesome as soon as it's released.
+* **Always up-to-date** - automatically fetches the most recent available version of Font Awesome, meaning you no longer need to manually update the version included in your theme/plugin.
 
-* **Backwards compatible** - shortcode output is automatically updated depending on which version you choose, meaning that you can switch versions without having to modify your shortcodes.
+* **Backwards compatible** - shortcode output is automatically updated depending on which version of Font Awesome you choose, meaning that you can switch versions without having to modify your shortcodes.
 
 * **Compatible with other plugins** - designed to work with shortcodes generated with plugins like [Font Awesome Icons](http://wordpress.org/plugins/font-awesome/ "Font Awesome Icons"), [Font Awesome More Icons](https://wordpress.org/plugins/font-awesome-more-icons/ "Font Awesome More Icons"), and [Font Awesome Shortcodes](https://wordpress.org/plugins/font-awesome-shortcodes/), so you can switch to Better Font Awesome and your existing shortcodes will still work.
 
-* **CDN speeds** - choose between the lightning quick [jsDelivr](http://www.jsdelivr.com/#!fontawesome) and [Bootstrap](http://www.bootstrapcdn.com/) CDNs, for super-fast loading of Font Awesome CSS.
+* **CDN speeds** - Font Awesome CSS is pulled from the super-fast and reliable [jsDelivr CDN](http://www.jsdelivr.com/#!fontawesome).
+
+* **Shortcode generator** - includes an easy-to-use TinyMCE dropdown shortcode generator.
 
 = Settings =
 All settings can be adjusted via **Settings &rarr; Better Font Awesome**.
@@ -32,44 +34,25 @@ All settings can be adjusted via **Settings &rarr; Better Font Awesome**.
 Better Font Awesome can be used in 3 different ways: shortcode, HTML, and TinyMCE
 
 = 1. Shortcode =
-`[icon name="flag" class="2x spin border" space="true"]`
+`[icon name="flag" class="2x spin border" unprefixed_class="my-custom-class"]`
+Note that prefixes (`fa-` and `icon-`) are not required, but if you do include them things will still work just fine! Better Font Awesome is smart enough to know what version of Font Awesome you're using and correct of the appropriate prefix.
 
-The **`name`** attribute is simply the name of the icon (see note below on prefixes, which are totally optional).
-
-The **`class`** attribute can include any of the available Font Awesome classes listed on the Font Awesome [Examples Page](http://fortawesome.github.io/Font-Awesome/examples/ "Font Awesome Examples").
-
-The **`space`** attribute (optional) can be used to include a `&nbsp;` within the generated `<i>` element.
-
-**Prefixes** (`icon-` and `fa-`) are not necessary for shortcode usage! What's great is that Better Font Awesome will automatically remove and replace prefixes depending on the Font Awesome version you choose. So if you have existing Font Awesome shortcodes *with prefixes* (from other plugins, for example), they'll still work just fine. 
-
-That means that the following shortcodes will all work, regardless of what version of Font Awesome you choose:
+That means that all of the following shortcodes will work, regardless of what version of Font Awesome you choose:
 `[icon name="flag" class="2x spin border"]`
 `[icon name="icon-flag" class="icon-2x icon-spin icon-border"]`
 `[icon name="fa-flag" class="fa-2x fa-spin fa-border"]`
 `[icon name="icon-flag" class="fa-2x spin icon-border"]`
 
-*Note: icon names and classes will only work for Font Awesome versions in which they are included.*
+You can read more about shortcode usage on [Github](https://github.com/MickeyKay/better-font-awesome-library#shortcode)
 
-= 2. HTML =
-Note that prefixes are required for HTML usage, and are version-specific. For this reason, shortcode usage is encouraged over HTML.
+= 2. TinyMCE =
+Better Font Awesome also provides you with an easy-to-use drop down menu when editing in TinyMCE's visual mode. Check out our [Screenshots](https://wordpress.org/plugins/better-font-awesome/screenshots/ "Screenshots") to see what it looks like.
 
-Version 4:
-`<i class="fa-flag fa-2x fa-spin fa-border"></i>`
-
-Version 3:
-`<i class="icon-flag icon-2x icon-spin icon-border"></i>`
-
-= 3. TinyMCE =
-Better Font Awesome also provides you with an easy-to-use drop down menu in the default WordPress TinyMCE, which you can use to automatically generate shortcodes for the icons you want. This drop-down list will automatically update with all available icons for whichever version you choose. Check out our [Screenshots](https://wordpress.org/plugins/better-font-awesome/screenshots/ "Screenshots") to see what it looks like.
+= 3. HTML =
+Note that prefixes are required for HTML usage, and are version-specific. For this reason, shortcode usage is encouraged over HTML. If you do want to use HTML, however, you can read more on the [Font Awesome site](http://fortawesome.github.io/Font-Awesome/examples/).
 
 = Advanced / Integration =
-Please feel free to integrate Better Font Awesome in your plugin or theme! If you want to hook into Better Font Awesome, the best way is via the global `$better_font_awesome` object, which has a few public properties that might be useful:
-
-`$better_font_awesome->prefix`
-The prefix (e.g. "icon-" or "fa-") that should be used with the selected version of Font Awesome.
-
-`$better_font_awesome->icons`
-An alphabetical array of all available icons based on the selected version of Font Awesome.
+Better Font Awesome is built around the [Better Font Awesome Library](https://github.com/MickeyKay/better-font-awesome-library). This library allows you to integrate Better Font Awesome into any custom project you want to create (perhaps a theme or plugin with a constantly up-to-date icon list), and includes all the [filters](https://github.com/MickeyKay/better-font-awesome-library#filters) you might need.
 
 
 = Credits =
@@ -93,7 +76,7 @@ And many thanks to the following folks who helped with testing and QA:
 
 This section describes how to install the plugin and get it working.
 
-1. Upload Font Awesome Icons to the /wp-content/plugins/ directory.
+1. Upload Better Font Awesome to the /wp-content/plugins/ directory.
 1. Activate the plugin through the 'Plugins' menu in WordPress.
 1. That's it! Now you can use 3 different methods (shortcode, HTML, TinyMCE) to insert Font Awesome icons, all outlined in the [Description](https://wordpress.org/plugins/better-font-awesome "Description") section.
 
@@ -106,7 +89,7 @@ This plugin is unique in that it automatically pulls in *all* available versions
 
 = Do I have to install any font files? =
 
-Nope. Better Font Awesome automatically pulls in everything you need, and it does it from the lightning-fast Bootstrap CDN.
+Nope. Better Font Awesome automatically pulls in everything you need, and it does it from the lightning-fast jsDelivr CDN.
 
 = What happens if I have another plugin/theme that uses Font Awesome? =
 
@@ -120,6 +103,13 @@ Better Font Awesome does it's best to load after any existing Font Awesome CSS, 
 
 
 == Changelog ==
+
+= 1.0.0 =
+* Fully refactor the back-end.
+* Switch to just using the jsDelivr CDN.
+* Implement transients to minimize load time.
+* Implement improved fallback handling (transient &rarr; wp_remote_get() &rarr; locally included files)
+* Switch out bulky Titan Framework for native Settings API.
 
 = 0.9.6 =
 * Fixed missing icon previews in WordPress 3.8 and below.
@@ -149,6 +139,13 @@ Better Font Awesome does it's best to load after any existing Font Awesome CSS, 
 
 
 == Upgrade Notice ==
+
+= 1.0.0 =
+* Fully refactor the back-end.
+* Switch to just using the jsDelivr CDN.
+* Implement transients to minimize load time.
+* Implement improved fallback handling (transient &rarr; wp_remote_get() &rarr; locally included files)
+* Switch out bulky Titan Framework for native Settings API.
 
 = 0.9.6 =
 * Fixed missing icon previews in WordPress 3.8 and below.


### PR DESCRIPTION
Summary of what I've done:

1. Added escaping functions, bearing in mind translations.
2. Limit what strings are available for translations (exclude examples of Font Awesome code markup, URLs back to plugin and so on). **NOTE** this will required `.pot` file re-generation.
3. Added a template for displaying usage text (to try to keep the main code cleaner and easier to understand).

@MickeyKay Please let me know what you think.