### PR TITLE
Fixes Font Awesome 5 URLs --- Fixes jQuery error to be compatible with WordPress 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Donate link:** https://mickeykay.me  
 **Requires at least:** 3.0  
 **Tested up to:** 5.5
-**Stable tag:** 1.7.1  
+**Stable tag:** 1.7.2  
 **License:** GPLv2+  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** better, font, awesome, icon, icons, bootstrap, fontstrap, cdn, shortcode  
 **Donate link:** https://mickeykay.me  
 **Requires at least:** 3.0  
-**Tested up to:** 5.4
+**Tested up to:** 5.5
 **Stable tag:** 1.7.1  
 **License:** GPLv2+  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** better, font, awesome, icon, icons, bootstrap, fontstrap, cdn, shortcode  
 **Donate link:** https://mickeykay.me  
 **Requires at least:** 3.0  
-**Tested up to:** 4.9  
+**Tested up to:** 5.4
 **Stable tag:** 1.7.1  
 **License:** GPLv2+  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/better-font-awesome.php
+++ b/better-font-awesome.php
@@ -12,7 +12,7 @@
  * Plugin Name:       Better Font Awesome
  * Plugin URI:        http://wordpress.org/plugins/better-font-awesome
  * Description:       The ultimate Font Awesome icon plugin for WordPress.
- * Version:           2.0.0-beta3
+ * Version:           2.0.0-beta4
  * Author:            Mickey Kay
  * Author URI:        mickeyskay@gmail.com
  * License:           GPLv2+

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: McGuive7
 Tags: better, font, awesome, icon, icons, bootstrap, fontstrap, cdn, shortcode
 Donate link: https://mickeykay.me
 Requires at least: 3.0
-Tested up to: 4.9
+Tested up to: 5.4
 Stable tag: 1.7.1
 License: GPLv2+
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: better, font, awesome, icon, icons, bootstrap, fontstrap, cdn, shortcode
 Donate link: https://mickeykay.me
 Requires at least: 3.0
 Tested up to: 5.5
-Stable tag: 1.7.1
+Stable tag: 1.7.2
 License: GPLv2+
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: McGuive7
 Tags: better, font, awesome, icon, icons, bootstrap, fontstrap, cdn, shortcode
 Donate link: https://mickeykay.me
 Requires at least: 3.0
-Tested up to: 5.4
+Tested up to: 5.5
 Stable tag: 1.7.1
 License: GPLv2+
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/vendor/mickey-kay/better-font-awesome-library/better-font-awesome-library.php
+++ b/vendor/mickey-kay/better-font-awesome-library/better-font-awesome-library.php
@@ -56,7 +56,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const JSDELIVR_ICON_METADATA_BASE_URL = 'https://cdn.jsdelivr.net/gh/FortAwesome/Font-Awesome@';
+	const JSDELIVR_ICON_METADATA_BASE_URL = 'https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@';
 
 	/**
 	 * jsDelivr API file path for Font Awesome icon metadata.
@@ -67,7 +67,7 @@ class Better_Font_Awesome_Library {
 	 *
 	 * @var    string
 	 */
-	const JSDELIVR_ICON_METADATA_FILE_PATH = '/advanced-options/metadata/icons.yml';
+	const JSDELIVR_ICON_METADATA_FILE_PATH = '/metadata/icons.yml';
 
 	/**
 	 * Initialization args.
@@ -690,7 +690,7 @@ class Better_Font_Awesome_Library {
 	 */
 	private function set_stylesheet_url( $version ) {
 		if ( version_compare( $version, '5.0.0', '>=' ) ) {
-			$this->stylesheet_url = '//cdn.jsdelivr.net/gh/FortAwesome/Font-Awesome@' . $version . '/web-fonts-with-css/css/fontawesome-all' . $this->get_min_suffix() . '.css';
+			$this->stylesheet_url = '//cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@' . $version . '/css/all' . $this->get_min_suffix() . '.css';
 		} else {
 			$this->stylesheet_url = '//cdn.jsdelivr.net/fontawesome/' . $version . '/css/font-awesome' . $this->get_min_suffix() . '.css';
 		}

--- a/vendor/mickey-kay/better-font-awesome-library/js/admin.js
+++ b/vendor/mickey-kay/better-font-awesome-library/js/admin.js
@@ -21,7 +21,7 @@
 		return '[icon name="' + icon.slug + '"' + icon_style_string + ' class="" unprefixed_class=""]';
 	}
 
-	$( document ).on( 'ready ', function() {
+	$( document ).ready( function() {
 
 		$( 'body' ).on( 'mousedown', '.bfa-iconpicker', function(e) { // Use mousedown even to allow for triggering click later without infinite looping.
 


### PR DESCRIPTION
Fixes a jsDelivr API error due some URLs have changed since the last update of **better-font-awesome-library**

After applying this fix, the error from the following image disappears:

![image](https://user-images.githubusercontent.com/4854377/86054248-ac39d080-ba0e-11ea-943a-ce703b9e993b.png)

--

I'm not sure if it's correct to edit code from the vendors directory or if we should update the code on the **better-font-awesome-library** first and then update the version of that library here. Any suggestion is really appreciated.

Finally, I have access to the WordPress Directory Plugins repository, but I'm not sure "how to clean the files" to upload only the "compiled" version of the plugin. I'm not very experienced with composer.