### PR TITLE
Add functionality to remove transients on upgrade

### DIFF
--- a/better-font-awesome.php
+++ b/better-font-awesome.php
@@ -383,6 +383,7 @@ class Better_Font_Awesome_Plugin {
         	if ( $options['action'] == 'update' && $options['type'] == 'plugin' && isset( $options['plugins'] ) ) {
         		foreach ( $options['plugins'] as $plugin ) {
         			if ( $plugin == $bfa_plugin ) {
+        				error_log( print_r('Better Font Awesome plugin updated! Clearing transients to ensure fresh data.', true) );
         				delete_transient( $this->bfa_lib::SLUG . '-api-versions' );
         				delete_transient( $this->bfa_lib::SLUG . '-css' );
         			}

--- a/better-font-awesome.php
+++ b/better-font-awesome.php
@@ -383,7 +383,6 @@ class Better_Font_Awesome_Plugin {
         	if ( $options['action'] == 'update' && $options['type'] == 'plugin' && isset( $options['plugins'] ) ) {
         		foreach ( $options['plugins'] as $plugin ) {
         			if ( $plugin == $bfa_plugin ) {
-        				error_log( print_r('Better Font Awesome plugin updated! Clearing transients to ensure fresh data.', true) );
         				delete_transient( $this->bfa_lib::SLUG . '-api-versions' );
         				delete_transient( $this->bfa_lib::SLUG . '-css' );
         			}

--- a/better-font-awesome.php
+++ b/better-font-awesome.php
@@ -177,6 +177,9 @@ class Better_Font_Awesome_Plugin {
         add_action( 'wp_ajax_bfa_save_options', array( $this, 'save_options' ) );
         add_action( 'wp_ajax_bfa_dismiss_testing_admin_notice', array( $this, 'dismiss_testing_admin_notice' ) );
 
+        // Clear transients on plugin update.
+        add_action( 'upgrader_process_complete', array( $this, 'handle_plugin_upgrade' ), 10, 2 );
+
     }
 
     /**
@@ -367,6 +370,25 @@ class Better_Font_Awesome_Plugin {
 
 		wp_die();
 	}
+
+	/**
+	 * Clear transients on plugin upgrade to ensure icon structure matches logic.
+	 *
+	 * @param  WP_Upgrader  $upgrader_object  Upgrader object.
+	 * @param  array 	    $options          Upgrade options.
+	 */
+	public function handle_plugin_upgrade( $upgrader_object, $options ) {
+        	$bfa_plugin = plugin_basename( __FILE__ );
+
+        	if ( $options['action'] == 'update' && $options['type'] == 'plugin' && isset( $options['plugins'] ) ) {
+        		foreach ( $options['plugins'] as $plugin ) {
+        			if ( $plugin == $bfa_plugin ) {
+        				delete_transient( $this->bfa_lib::SLUG . '-api-versions' );
+        				delete_transient( $this->bfa_lib::SLUG . '-css' );
+        			}
+        		}
+        	}
+        }
 
     /**
      * Create the plugin settings page.


### PR DESCRIPTION
NOTE: this PR includes BFAL@1.4.7 which is busted. We need to reapply all the following updates related to 1.4.7, but roll back the brokenness that was accidentally include in the 1.4.7 release (e.g. updating `JSDELIVR_API_URL`):
- ensure admin notice dismiss is working (remove included dismiss button, which WP now handles)
- remove all calls to jQuery `ready()`